### PR TITLE
Implemented the user service interface correctly

### DIFF
--- a/JoolServerApp.Data/JoolServerApp.Data.csproj.user
+++ b/JoolServerApp.Data/JoolServerApp.Data.csproj.user
@@ -9,6 +9,7 @@
     <IISExpressUseClassicPipelineMode />
     <UseGlobalApplicationHostFile />
     <LastActiveSolutionConfig>Debug|Any CPU</LastActiveSolutionConfig>
+    <ProjectView>ShowAllFiles</ProjectView>
   </PropertyGroup>
   <ProjectExtensions>
     <VisualStudio>

--- a/JoolServerApp.Repo/IRepository.cs
+++ b/JoolServerApp.Repo/IRepository.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace JoolServerApp.Repo
 {
-    public interface IRepository<T> where T : JoolServerEntities
+    public interface IRepository<T> where T : class
     {
         IEnumerable<T> GetAll();
         T Get(long id);

--- a/JoolServerApp.Repo/JoolServerApp.Repo.csproj
+++ b/JoolServerApp.Repo/JoolServerApp.Repo.csproj
@@ -79,8 +79,10 @@
     <Content Include="Web.config" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="IRepository.cs" />
     <Compile Include="JoolServer.Context.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Repository.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/JoolServerApp.Repo/JoolServerApp.Repo.csproj.user
+++ b/JoolServerApp.Repo/JoolServerApp.Repo.csproj.user
@@ -9,6 +9,7 @@
     <IISExpressUseClassicPipelineMode />
     <UseGlobalApplicationHostFile />
     <LastActiveSolutionConfig>Debug|Any CPU</LastActiveSolutionConfig>
+    <ProjectView>ShowAllFiles</ProjectView>
   </PropertyGroup>
   <ProjectExtensions>
     <VisualStudio>

--- a/JoolServerApp.Repo/Repository.cs
+++ b/JoolServerApp.Repo/Repository.cs
@@ -8,7 +8,7 @@ using System.Data.Entity.Infrastructure;
 
 namespace JoolServerApp.Repo
 {
-    public class Repository<T> : IRepository<T> where T : JoolServerEntities
+    public class Repository<T> : IRepository<T> where T : class
     {
         private readonly JoolServerEntities context;
         private DbSet<T> entities;

--- a/JoolServerApp.Service/IUserService.cs
+++ b/JoolServerApp.Service/IUserService.cs
@@ -2,10 +2,16 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Web;
+using JoolServerApp.Data;
 
 namespace JoolServerApp.Service
 {
-    public class IUserService
+    public interface IUserService
     {
+        IEnumerable<tblUser> GetUsers();
+        tblUser GetUser(long id);
+        void insertUser(tblUser user);
+        void UpdateUser(tblUser user);
+        void DeleteUser(long id);
     }
 }

--- a/JoolServerApp.Service/JoolServerApp.Service.csproj
+++ b/JoolServerApp.Service/JoolServerApp.Service.csproj
@@ -70,6 +70,8 @@
     <Content Include="Web.config" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="IUserService.cs" />
+    <Compile Include="UserService.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Test\testClass.cs" />
   </ItemGroup>
@@ -83,6 +85,10 @@
     </None>
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\JoolServerApp.Data\JoolServerApp.Data.csproj">
+      <Project>{5E7AD55F-D9DB-4D4E-B090-D9C9595F5DEE}</Project>
+      <Name>JoolServerApp.Data</Name>
+    </ProjectReference>
     <ProjectReference Include="..\JoolServerApp.Repo\JoolServerApp.Repo.csproj">
       <Project>{b0192b07-461d-41b9-9111-a4ecb6c2783a}</Project>
       <Name>JoolServerApp.Repo</Name>

--- a/JoolServerApp.Service/JoolServerApp.Service.csproj.user
+++ b/JoolServerApp.Service/JoolServerApp.Service.csproj.user
@@ -9,6 +9,7 @@
     <IISExpressUseClassicPipelineMode />
     <UseGlobalApplicationHostFile />
     <LastActiveSolutionConfig>Debug|Any CPU</LastActiveSolutionConfig>
+    <ProjectView>ShowAllFiles</ProjectView>
   </PropertyGroup>
   <ProjectExtensions>
     <VisualStudio>

--- a/JoolServerApp.Service/UserService.cs
+++ b/JoolServerApp.Service/UserService.cs
@@ -27,7 +27,7 @@ namespace JoolServerApp.Service
         }
         public void UpdateUser(tblUser user)
         {
-            userRepository.Update(user)
+            userRepository.Update(user);
         }
 
         public void DeleteUser(long id)

--- a/JoolServerApp.Service/UserService.cs
+++ b/JoolServerApp.Service/UserService.cs
@@ -1,0 +1,41 @@
+﻿using System.Collections.Generic;
+using JoolServerApp.Repo;
+using JoolServerApp.Data;
+
+namespace JoolServerApp.Service
+{
+    public class UserService:IUserService
+    {
+        private IRepository<tblUser> userRepository;
+
+        public UserService(IRepository<tblUser> userRepository)
+        {
+            this.userRepository = userRepository;
+        }
+
+        public IEnumerable<tblUser> GetUsers()
+        {
+            return userRepository.GetAll();
+        }
+        public tblUser GetUser(long id)
+        {
+            return userRepository.Get(id);
+        }
+        public void insertUser(tblUser user)
+        {
+            userRepository.Insert(user);
+        }
+        public void UpdateUser(tblUser user)
+        {
+            userRepository.Update(user)
+        }
+
+        public void DeleteUser(long id)
+        {
+            tblUser user = GetUser(id);
+            userRepository.Remove(user);
+            userRepository.SaveChanges();
+        }
+
+    }
+}


### PR DESCRIPTION
      I figured out what we were doing wrong. So the generic type(i.e. T) we used initially for the IRepository interface should have been of type "class" and not "JouleServerEntities" since when we create an instance of IRepository (i.e. userRepository inside the UserService.cs implementation file), we want to use the individual base entities the E.F creates for us in the .Data section and since they aare of type class then the generic type T of our Irepository interface should also be of type "class" for consistency. So if you hover your mouse around each of the individual table entities used to create the DBSet<T> JooleServerEntities type Entities, each of them is of type "class" and since we are using the generic types to implement specific services and not a whole DBSet<T> Entity, the type T should be a "class" and not a "JouleServerEntities". I can explain it better to anyone who doesn't get it later. 